### PR TITLE
Update result type templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ RESET=`tput sgr0`
 YELLOW=`tput setaf 3`
 
 PLONE_VERSION=6
-VOLTO_VERSION=16.10.0
+VOLTO_VERSION=17.0.0-alpha.24
 
 ADDON_NAME='@kitconcept/volto-solr'
 ADDON_PATH='volto-solr'

--- a/news/9.feature
+++ b/news/9.feature
@@ -1,0 +1,1 @@
+Update result type templates @reebalazs

--- a/src/components/theme/SolrSearch/resultItems/DefaultResultItem.jsx
+++ b/src/components/theme/SolrSearch/resultItems/DefaultResultItem.jsx
@@ -4,6 +4,7 @@ import ResultItemDate, { thresholdDate } from './helpers/ResultItemDate';
 import { Icon } from '@plone/volto/components';
 import documentSVG from '@plone/volto/icons/doument-details.svg';
 import ConcatChildren from './helpers/ConcatChildren';
+import ResultItemPreviewImage from './helpers/ResultItemPreviewImage';
 
 // import { FormattedMessage } from 'react-intl';
 
@@ -19,6 +20,7 @@ const DefaultResultItem = ({ item }) => (
     {/* <span className="contentTypeLabel">
       <FormattedMessage id={mapContentTypes(item['@type'])} />
     </span> */}
+    <ResultItemPreviewImage item={item} />
     <p className="url">{item['@id']}</p>
     <h2 className="tileHeadline">
       <Link to={item['@id']} className="summary url" title={item['@type']}>

--- a/src/components/theme/SolrSearch/resultItems/DefaultResultItem.jsx
+++ b/src/components/theme/SolrSearch/resultItems/DefaultResultItem.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import ResultItemDate, { thresholdDate } from './helpers/ResultItemDate';
 import { Icon } from '@plone/volto/components';
-import documentSVG from '@plone/volto/icons/doument-details.svg';
+import fileSVG from '@plone/volto/icons/file.svg';
 import ConcatChildren from './helpers/ConcatChildren';
 import ResultItemPreviewImage from './helpers/ResultItemPreviewImage';
 
@@ -57,7 +57,7 @@ const DefaultResultItem = ({ item }) => (
           }
           if2={false}
         >
-          <Icon className="itemIcon" size="20px" name={documentSVG} />
+          <Icon className="itemIcon" size="20px" name={fileSVG} />
           <ResultItemDate
             date={item?.extras?.start ? item.extras.start : item?.effective}
           />

--- a/src/components/theme/SolrSearch/resultItems/EventResultItem.jsx
+++ b/src/components/theme/SolrSearch/resultItems/EventResultItem.jsx
@@ -4,12 +4,14 @@ import { Icon } from '@plone/volto/components';
 import ResultItemDate from './helpers/ResultItemDate';
 import locationSVG from '../icons/location.svg';
 import calendarSVG from '@plone/volto/icons/calendar.svg';
+import ResultItemPreviewImage from './helpers/ResultItemPreviewImage';
 
 const EventResultItem = ({ item }) => (
   <article className="tileItem">
     {/* <span className="contentTypeLabel">
       <FormattedMessage id={mapContentTypes(item['@type'])} />
     </span> */}
+    <ResultItemPreviewImage item={item} />
     <p className="url">{item['@id']}</p>
     <h2 className="tileHeadline">
       <Link to={item['@id']} className="summary url" title={item['@type']}>

--- a/src/components/theme/SolrSearch/resultItems/ImageResultItem.jsx
+++ b/src/components/theme/SolrSearch/resultItems/ImageResultItem.jsx
@@ -5,19 +5,14 @@ import { Icon } from '@plone/volto/components';
 import imageSVG from '@plone/volto/icons/image.svg';
 import ConcatChildren from './helpers/ConcatChildren';
 import ImageType, { getImageType } from './helpers/ImageType';
+import ResultItemPreviewImage from './helpers/ResultItemPreviewImage';
 
 const ImageResultItem = ({ item }) => (
   <article className="tileItem">
     {/* <span className="contentTypeLabel">
       <FormattedMessage id={mapContentTypes(item['@type'])} />
     </span> */}
-    <Link to={item['@id']}>
-      <img
-        className="previewImage"
-        src={`${item['@id']}/@@images/image/preview`}
-        alt={item.title}
-      />
-    </Link>
+    <ResultItemPreviewImage item={item} />
     <p className="url">{item['@id']}</p>
     <h2 className="tileHeadline">
       <Link to={item['@id']} className="summary url" title={item['@type']}>

--- a/src/components/theme/SolrSearch/resultItems/NewsItemResultItem.jsx
+++ b/src/components/theme/SolrSearch/resultItems/NewsItemResultItem.jsx
@@ -5,19 +5,14 @@ import { Icon } from '@plone/volto/components';
 import newsSVG from '@plone/volto/icons/news.svg';
 import ConcatChildren from './helpers/ConcatChildren';
 import ImageType, { getImageType } from './helpers/ImageType';
+import ResultItemPreviewImage from './helpers/ResultItemPreviewImage';
 
 const NewsItemResultItem = ({ item }) => (
   <article className="tileItem">
     {/* <span className="contentTypeLabel">
       <FormattedMessage id={mapContentTypes(item['@type'])} />
     </span> */}
-    <Link to={item['@id']}>
-      <img
-        className="previewImage"
-        src={`${item['@id']}/@@images/image/preview`}
-        alt={item.title}
-      />
-    </Link>
+    <ResultItemPreviewImage item={item} />
     <p className="url">{item['@id']}</p>
     <h2 className="tileHeadline">
       <Link to={item['@id']} className="summary url" title={item['@type']}>

--- a/src/components/theme/SolrSearch/resultItems/helpers/LegacyImage.jsx
+++ b/src/components/theme/SolrSearch/resultItems/helpers/LegacyImage.jsx
@@ -1,0 +1,50 @@
+import { Link } from 'react-router-dom';
+import { flattenToAppURL } from '@plone/volto/helpers';
+
+// Compatibility layer for Volto < 17, where the Image content type
+// is not present.
+
+export const previewImageLink = (
+  { image_scales, image_field },
+  minWidth = 250,
+) => {
+  const requiredPixels = minWidth * window.devicePixelRatio;
+  let download;
+  // Find the next larger resolution to what we require
+  if (image_scales) {
+    const scales = Object.values(image_scales?.[image_field]?.[0].scales).sort(
+      (a, b) => a.width - b.width,
+    );
+    for (const scale of scales) {
+      if (scale.width >= requiredPixels) {
+        download = scale.download;
+        break;
+      }
+    }
+    if (!download) {
+      // if no best scale, try using the largest
+      download = scales[scales.length - 1]?.download;
+    }
+  }
+  // In case of missing scale no image.
+  return download;
+};
+
+const LegacyImage = ({ item, minWidth, ...rest }) => {
+  const download = previewImageLink(item, minWidth);
+  if (download) {
+    return (
+      <Link to={item['@id']}>
+        <img
+          src={flattenToAppURL(`${item['@id']}/${download}`)}
+          alt={item.title}
+          {...rest}
+        />
+      </Link>
+    );
+  } else {
+    return null;
+  }
+};
+
+export default LegacyImage;

--- a/src/components/theme/SolrSearch/resultItems/helpers/LegacyImage.test.jsx
+++ b/src/components/theme/SolrSearch/resultItems/helpers/LegacyImage.test.jsx
@@ -1,0 +1,217 @@
+import { create } from 'react-test-renderer';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import LegacyImage, { previewImageLink } from './LegacyImage';
+
+jest.mock('@plone/volto/helpers', () => {
+  return {
+    __esModule: true,
+    flattenToAppURL: jest.fn((url) =>
+      url.replace(/http:\/\/localhost:3000/, ''),
+    ),
+    isInternalURL: jest.fn(
+      (url) =>
+        url.search(/http:\/\/localhost:3000/) !== -1 ||
+        url.search(/http:\/\//) === -1,
+    ),
+  };
+});
+
+const data = {
+  '@id': '/testnews1',
+  image_field: 'preview_image',
+  image_scales: {
+    preview_image: [
+      {
+        filename: 'GOPR9639.JPG',
+        'content-type': 'image/jpeg',
+        size: 6446468,
+        download:
+          '@@images/preview_image-4000-5496e5d01152aa6661428d9e264d3757.jpeg',
+        width: 4000,
+        height: 3000,
+        scales: {
+          icon: {
+            download:
+              '@@images/preview_image-32-e743dcfb64ce39b0660285a04e7f842b.jpeg',
+            width: 32,
+            height: 24,
+          },
+          tile: {
+            download:
+              '@@images/preview_image-64-9ad26e8053451aec63586d66e111deb8.jpeg',
+            width: 64,
+            height: 48,
+          },
+          thumb: {
+            download:
+              '@@images/preview_image-128-88f2831a9f099921f03d3244021b03ab.jpeg',
+            width: 128,
+            height: 96,
+          },
+          mini: {
+            download:
+              '@@images/preview_image-200-2a8af40b17e1f5562607a1cf876244b1.jpeg',
+            width: 200,
+            height: 150,
+          },
+          preview: {
+            download:
+              '@@images/preview_image-400-1a82684a51b55644eef2807c2761b711.jpeg',
+            width: 400,
+            height: 300,
+          },
+          teaser: {
+            download:
+              '@@images/preview_image-600-71895aac86b72d21dd0f2bad189871c3.jpeg',
+            width: 600,
+            height: 450,
+          },
+          large: {
+            download:
+              '@@images/preview_image-800-b30bff7dbaa62fc6aca82639c9f5ee97.jpeg',
+            width: 800,
+            height: 600,
+          },
+          larger: {
+            download:
+              '@@images/preview_image-1000-e97d87c2a35fdc6262f429262854faed.jpeg',
+            width: 1000,
+            height: 750,
+          },
+          great: {
+            download:
+              '@@images/preview_image-1200-0723c41835b6498e598780419cc25a4f.jpeg',
+            width: 1200,
+            height: 900,
+          },
+          huge: {
+            download:
+              '@@images/preview_image-1600-7c8256769b8c48d0392c6a51ef34a139.jpeg',
+            width: 1600,
+            height: 1200,
+          },
+        },
+      },
+    ],
+  },
+};
+
+const dataMissingScales = {
+  '@id': '/testnews1',
+  image_field: 'preview_image',
+  image_scales: undefined,
+};
+
+describe('ResultItemPreviewImageLegacy previewImageLink', () => {
+  beforeEach(() => {
+    window.devicePixelRatio = 1;
+  });
+
+  describe('generates image link', () => {
+    it('normal', () => {
+      expect(previewImageLink(data)).toBe(
+        '@@images/preview_image-400-1a82684a51b55644eef2807c2761b711.jpeg',
+      );
+    });
+    it('minWidth chooses smallest possible scale', () => {
+      expect(previewImageLink(data, 600)).toBe(
+        '@@images/preview_image-600-71895aac86b72d21dd0f2bad189871c3.jpeg',
+      );
+    });
+    it('minWidth works with devicePixelRatio', () => {
+      window.devicePixelRatio = 2.0;
+      expect(previewImageLink(data, 600)).toBe(
+        '@@images/preview_image-1200-0723c41835b6498e598780419cc25a4f.jpeg',
+      );
+    });
+    it('minWidth chooses largest scale if they are all too small', () => {
+      expect(previewImageLink(data, 6000)).toBe(
+        '@@images/preview_image-1600-7c8256769b8c48d0392c6a51ef34a139.jpeg',
+      );
+    });
+  });
+  describe('fallback', () => {
+    it('missing scales', () => {
+      expect(previewImageLink(dataMissingScales)).toBe(undefined);
+    });
+    it('minWidth works with missing scales', () => {
+      expect(previewImageLink(dataMissingScales, 250)).toBe(undefined);
+    });
+  });
+});
+
+describe('LegacyImage', () => {
+  let history;
+
+  beforeEach(() => {
+    history = createMemoryHistory();
+    history.push = jest.fn();
+    window.devicePixelRatio = 1;
+  });
+
+  test('normal', () => {
+    const component = create(
+      <Router history={history}>
+        <LegacyImage item={data} />
+      </Router>,
+    );
+    const rendered = component.toJSON();
+    expect(rendered).toMatchSnapshot();
+  });
+
+  test('minWidth', () => {
+    const component = create(
+      <Router history={history}>
+        <LegacyImage item={data} minWidth={600} />
+      </Router>,
+    );
+    const rendered = component.toJSON();
+    expect(rendered).toMatchSnapshot();
+  });
+
+  test('minWidth and devicePixelRatio', () => {
+    window.devicePixelRatio = 2;
+    const component = create(
+      <Router history={history}>
+        <LegacyImage item={data} minWidth={600} />
+      </Router>,
+    );
+    const rendered = component.toJSON();
+    expect(rendered).toMatchSnapshot();
+  });
+
+  test('renders null if resolution is not available', () => {
+    const component = create(
+      <Router history={history}>
+        <LegacyImage
+          item={dataMissingScales}
+          minWidth={600}
+          className="foo"
+          width="120"
+          height="130"
+          loading="eager"
+        />
+      </Router>,
+    );
+    const rendered = component.toJSON();
+    expect(rendered).toBe(null);
+  });
+
+  test('override via rest', () => {
+    const component = create(
+      <Router history={history}>
+        <LegacyImage
+          item={data}
+          minWidth={600}
+          className="foo"
+          width="120"
+          height="130"
+          loading="eager"
+        />
+      </Router>,
+    );
+    const rendered = component.toJSON();
+    expect(rendered).toMatchSnapshot();
+  });
+});

--- a/src/components/theme/SolrSearch/resultItems/helpers/ResultItemPreviewImage.jsx
+++ b/src/components/theme/SolrSearch/resultItems/helpers/ResultItemPreviewImage.jsx
@@ -1,0 +1,47 @@
+import { Link } from 'react-router-dom';
+import config from '@plone/volto/registry';
+
+export const previewImageContent = ({
+  '@id': id,
+  extras: { image_scales: rawImageScales },
+  image_field,
+}) => {
+  let image_scales;
+  try {
+    image_scales = JSON.parse(rawImageScales);
+  } catch {}
+  // In case of json error, image_scales will be undefined..
+  return {
+    '@id': id,
+    image_scales,
+    image_field,
+  };
+};
+
+const ResultItemPreviewImage = ({ item, ...rest }) => {
+  const content = previewImageContent(item);
+  if (content.image_scales) {
+    // Show the link also conditionally.
+    const Image = config.getComponent({ name: 'Image' }).component;
+    return (
+      <Link to={item['@id']}>
+        <Image
+          item={content}
+          alt={item.title}
+          /* Default hints provided, can be overridden via rest */
+          className="previewImage"
+          loading="lazy"
+          sizes="250px"
+          /* width + height practically mandatory, see https://github.com/plone/volto/issues/5096 */
+          width="250"
+          height="125"
+          {...rest}
+        />
+      </Link>
+    );
+  } else {
+    return null;
+  }
+};
+
+export default ResultItemPreviewImage;

--- a/src/components/theme/SolrSearch/resultItems/helpers/ResultItemPreviewImage.test.jsx
+++ b/src/components/theme/SolrSearch/resultItems/helpers/ResultItemPreviewImage.test.jsx
@@ -1,0 +1,167 @@
+import { create } from 'react-test-renderer';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import ResultItemPreviewImage, {
+  previewImageContent,
+} from './ResultItemPreviewImage';
+
+const data = {
+  '@id': '/testnews1',
+  image_field: 'preview_image',
+  extras: {
+    image_scales: `{"preview_image": [{"filename": "GOPR9639.JPG", "content-type": "image/jpeg", "size": 6446468, "download": "@@images/preview_image-4000-5496e5d01152aa6661428d9e264d3757.jpeg", "width": 4000, "height": 3000, "scales": {"icon": {"download": "@@images/preview_image-32-e743dcfb64ce39b0660285a04e7f842b.jpeg", "width": 32, "height": 24}, "tile": {"download": "@@images/preview_image-64-9ad26e8053451aec63586d66e111deb8.jpeg", "width": 64, "height": 48}, "thumb": {"download": "@@images/preview_image-128-88f2831a9f099921f03d3244021b03ab.jpeg", "width": 128, "height": 96}, "mini": {"download": "@@images/preview_image-200-2a8af40b17e1f5562607a1cf876244b1.jpeg", "width": 200, "height": 150}, "preview": {"download": "@@images/preview_image-400-1a82684a51b55644eef2807c2761b711.jpeg", "width": 400, "height": 300}, "teaser": {"download": "@@images/preview_image-600-71895aac86b72d21dd0f2bad189871c3.jpeg", "width": 600, "height": 450}, "large": {"download": "@@images/preview_image-800-b30bff7dbaa62fc6aca82639c9f5ee97.jpeg", "width": 800, "height": 600}, "larger": {"download": "@@images/preview_image-1000-e97d87c2a35fdc6262f429262854faed.jpeg", "width": 1000, "height": 750}, "great": {"download": "@@images/preview_image-1200-0723c41835b6498e598780419cc25a4f.jpeg", "width": 1200, "height": 900}, "huge": {"download": "@@images/preview_image-1600-7c8256769b8c48d0392c6a51ef34a139.jpeg", "width": 1600, "height": 1200}}}]}`,
+  },
+};
+
+const dataBrokenJson = {
+  '@id': '/testnews1',
+  image_field: 'preview_image',
+  extras: {
+    image_scales: `{BROKEN JSON}`,
+  },
+};
+
+const dataMissingScales = {
+  '@id': '/testnews1',
+  image_field: 'preview_image',
+  extras: {
+    image_scales: undefined,
+  },
+};
+
+describe('ResultItemPreviewImage previewImageContent', () => {
+  it('generates image data', () => {
+    expect(previewImageContent(data)).toEqual({
+      '@id': '/testnews1',
+      image_field: 'preview_image',
+      image_scales: {
+        preview_image: [
+          {
+            'content-type': 'image/jpeg',
+            download:
+              '@@images/preview_image-4000-5496e5d01152aa6661428d9e264d3757.jpeg',
+            filename: 'GOPR9639.JPG',
+            height: 3000,
+            scales: {
+              great: {
+                download:
+                  '@@images/preview_image-1200-0723c41835b6498e598780419cc25a4f.jpeg',
+                height: 900,
+                width: 1200,
+              },
+              huge: {
+                download:
+                  '@@images/preview_image-1600-7c8256769b8c48d0392c6a51ef34a139.jpeg',
+                height: 1200,
+                width: 1600,
+              },
+              icon: {
+                download:
+                  '@@images/preview_image-32-e743dcfb64ce39b0660285a04e7f842b.jpeg',
+                height: 24,
+                width: 32,
+              },
+              large: {
+                download:
+                  '@@images/preview_image-800-b30bff7dbaa62fc6aca82639c9f5ee97.jpeg',
+                height: 600,
+                width: 800,
+              },
+              larger: {
+                download:
+                  '@@images/preview_image-1000-e97d87c2a35fdc6262f429262854faed.jpeg',
+                height: 750,
+                width: 1000,
+              },
+              mini: {
+                download:
+                  '@@images/preview_image-200-2a8af40b17e1f5562607a1cf876244b1.jpeg',
+                height: 150,
+                width: 200,
+              },
+              preview: {
+                download:
+                  '@@images/preview_image-400-1a82684a51b55644eef2807c2761b711.jpeg',
+                height: 300,
+                width: 400,
+              },
+              teaser: {
+                download:
+                  '@@images/preview_image-600-71895aac86b72d21dd0f2bad189871c3.jpeg',
+                height: 450,
+                width: 600,
+              },
+              thumb: {
+                download:
+                  '@@images/preview_image-128-88f2831a9f099921f03d3244021b03ab.jpeg',
+                height: 96,
+                width: 128,
+              },
+              tile: {
+                download:
+                  '@@images/preview_image-64-9ad26e8053451aec63586d66e111deb8.jpeg',
+                height: 48,
+                width: 64,
+              },
+            },
+            size: 6446468,
+            width: 4000,
+          },
+        ],
+      },
+    });
+  });
+  describe('fallback', () => {
+    it('bad json yields empty image_scales', () => {
+      expect(previewImageContent(dataBrokenJson)).toEqual({
+        '@id': '/testnews1',
+        image_field: 'preview_image',
+        image_scales: undefined,
+      });
+    });
+    it('missing scales yields empty image_scales', () => {
+      expect(previewImageContent(dataMissingScales)).toEqual({
+        '@id': '/testnews1',
+        image_field: 'preview_image',
+        image_scales: undefined,
+      });
+    });
+  });
+});
+
+describe('ResultItemPreviewImage', () => {
+  let history;
+
+  beforeEach(() => {
+    history = createMemoryHistory();
+    history.push = jest.fn();
+    window.devicePixelRatio = 1;
+  });
+
+  test('normal with default props', () => {
+    const component = create(
+      <Router history={history}>
+        <ResultItemPreviewImage item={data} />
+      </Router>,
+    );
+    const rendered = component.toJSON();
+    expect(rendered).toMatchSnapshot();
+  });
+
+  test('override via rest', () => {
+    const component = create(
+      <Router history={history}>
+        <ResultItemPreviewImage
+          item={data}
+          className="foo"
+          width="120"
+          height="130"
+          loading="eager"
+          sizes="100vw"
+        />
+      </Router>,
+    );
+    const rendered = component.toJSON();
+    expect(rendered).toMatchSnapshot();
+  });
+});

--- a/src/components/theme/SolrSearch/resultItems/helpers/ResultItemPreviewImage.test.jsx
+++ b/src/components/theme/SolrSearch/resultItems/helpers/ResultItemPreviewImage.test.jsx
@@ -1,5 +1,6 @@
 import { create } from 'react-test-renderer';
 import { Router } from 'react-router-dom';
+import config from '@plone/volto/registry';
 import { createMemoryHistory } from 'history';
 import ResultItemPreviewImage, {
   previewImageContent,
@@ -163,5 +164,74 @@ describe('ResultItemPreviewImage', () => {
     );
     const rendered = component.toJSON();
     expect(rendered).toMatchSnapshot();
+  });
+
+  describe('legacy image', () => {
+    let origComponent;
+    let origContentTypeSearchResultAlwaysUseLegacyImage;
+    beforeEach(() => {
+      origComponent = config.getComponent({ name: 'Image' }).component;
+      origContentTypeSearchResultAlwaysUseLegacyImage =
+        config.settings.contentTypeSearchResultAlwaysUseLegacyImage;
+    });
+    afterEach(() => {
+      config.getComponent({ name: 'Image' }).component = origComponent;
+      config.settings.contentTypeSearchResultAlwaysUseLegacyImage = origContentTypeSearchResultAlwaysUseLegacyImage;
+    });
+
+    test('if image component not available on Volto 16', () => {
+      config.getComponent({ name: 'Image' }).component = undefined;
+      const component = create(
+        <Router history={history}>
+          <ResultItemPreviewImage
+            item={data}
+            className="foo"
+            width="120"
+            height="130"
+            loading="eager"
+          />
+        </Router>,
+      );
+      const rendered = component.toJSON();
+      expect(rendered).toMatchSnapshot();
+    });
+
+    test('if contentTypeSearchResultAlwaysUseLegacyImage is true', () => {
+      config.settings.contentTypeSearchResultAlwaysUseLegacyImage = true;
+      const component = create(
+        <Router history={history}>
+          <ResultItemPreviewImage
+            item={data}
+            className="foo"
+            width="120"
+            height="130"
+            loading="eager"
+          />
+        </Router>,
+      );
+      const rendered = component.toJSON();
+      expect(rendered).toMatchSnapshot();
+    });
+
+    test('sizes prop yields error', () => {
+      config.settings.contentTypeSearchResultAlwaysUseLegacyImage = true;
+      let mockError = jest.spyOn(console, 'error');
+      mockError.mockImplementation(() => undefined);
+      expect(() =>
+        create(
+          <Router history={history}>
+            <ResultItemPreviewImage
+              item={data}
+              className="foo"
+              width="120"
+              height="130"
+              loading="eager"
+              sizes="100vw"
+            />
+          </Router>,
+        ),
+      ).toThrow();
+      mockError.mockRestore();
+    });
   });
 });

--- a/src/components/theme/SolrSearch/resultItems/helpers/__snapshots__/LegacyImage.test.jsx.snap
+++ b/src/components/theme/SolrSearch/resultItems/helpers/__snapshots__/LegacyImage.test.jsx.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LegacyImage minWidth 1`] = `
+<a
+  href="/testnews1"
+  onClick={[Function]}
+>
+  <img
+    src="/testnews1/@@images/preview_image-600-71895aac86b72d21dd0f2bad189871c3.jpeg"
+  />
+</a>
+`;
+
+exports[`LegacyImage minWidth and devicePixelRatio 1`] = `
+<a
+  href="/testnews1"
+  onClick={[Function]}
+>
+  <img
+    src="/testnews1/@@images/preview_image-1200-0723c41835b6498e598780419cc25a4f.jpeg"
+  />
+</a>
+`;
+
+exports[`LegacyImage normal 1`] = `
+<a
+  href="/testnews1"
+  onClick={[Function]}
+>
+  <img
+    src="/testnews1/@@images/preview_image-400-1a82684a51b55644eef2807c2761b711.jpeg"
+  />
+</a>
+`;
+
+exports[`LegacyImage override via rest 1`] = `
+<a
+  href="/testnews1"
+  onClick={[Function]}
+>
+  <img
+    className="foo"
+    height="130"
+    loading="eager"
+    src="/testnews1/@@images/preview_image-600-71895aac86b72d21dd0f2bad189871c3.jpeg"
+    width="120"
+  />
+</a>
+`;

--- a/src/components/theme/SolrSearch/resultItems/helpers/__snapshots__/ResultItemPreviewImage.test.jsx.snap
+++ b/src/components/theme/SolrSearch/resultItems/helpers/__snapshots__/ResultItemPreviewImage.test.jsx.snap
@@ -1,0 +1,171 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ResultItemPreviewImage normal with default props 1`] = `
+<a
+  href="/testnews1"
+  onClick={[Function]}
+>
+  <img
+    className="previewImage"
+    height="125"
+    item={
+      Object {
+        "@id": "/testnews1",
+        "image_field": "preview_image",
+        "image_scales": Object {
+          "preview_image": Array [
+            Object {
+              "content-type": "image/jpeg",
+              "download": "@@images/preview_image-4000-5496e5d01152aa6661428d9e264d3757.jpeg",
+              "filename": "GOPR9639.JPG",
+              "height": 3000,
+              "scales": Object {
+                "great": Object {
+                  "download": "@@images/preview_image-1200-0723c41835b6498e598780419cc25a4f.jpeg",
+                  "height": 900,
+                  "width": 1200,
+                },
+                "huge": Object {
+                  "download": "@@images/preview_image-1600-7c8256769b8c48d0392c6a51ef34a139.jpeg",
+                  "height": 1200,
+                  "width": 1600,
+                },
+                "icon": Object {
+                  "download": "@@images/preview_image-32-e743dcfb64ce39b0660285a04e7f842b.jpeg",
+                  "height": 24,
+                  "width": 32,
+                },
+                "large": Object {
+                  "download": "@@images/preview_image-800-b30bff7dbaa62fc6aca82639c9f5ee97.jpeg",
+                  "height": 600,
+                  "width": 800,
+                },
+                "larger": Object {
+                  "download": "@@images/preview_image-1000-e97d87c2a35fdc6262f429262854faed.jpeg",
+                  "height": 750,
+                  "width": 1000,
+                },
+                "mini": Object {
+                  "download": "@@images/preview_image-200-2a8af40b17e1f5562607a1cf876244b1.jpeg",
+                  "height": 150,
+                  "width": 200,
+                },
+                "preview": Object {
+                  "download": "@@images/preview_image-400-1a82684a51b55644eef2807c2761b711.jpeg",
+                  "height": 300,
+                  "width": 400,
+                },
+                "teaser": Object {
+                  "download": "@@images/preview_image-600-71895aac86b72d21dd0f2bad189871c3.jpeg",
+                  "height": 450,
+                  "width": 600,
+                },
+                "thumb": Object {
+                  "download": "@@images/preview_image-128-88f2831a9f099921f03d3244021b03ab.jpeg",
+                  "height": 96,
+                  "width": 128,
+                },
+                "tile": Object {
+                  "download": "@@images/preview_image-64-9ad26e8053451aec63586d66e111deb8.jpeg",
+                  "height": 48,
+                  "width": 64,
+                },
+              },
+              "size": 6446468,
+              "width": 4000,
+            },
+          ],
+        },
+      }
+    }
+    loading="lazy"
+    sizes="250px"
+    width="250"
+  />
+</a>
+`;
+
+exports[`ResultItemPreviewImage override via rest 1`] = `
+<a
+  href="/testnews1"
+  onClick={[Function]}
+>
+  <img
+    className="foo"
+    height="130"
+    item={
+      Object {
+        "@id": "/testnews1",
+        "image_field": "preview_image",
+        "image_scales": Object {
+          "preview_image": Array [
+            Object {
+              "content-type": "image/jpeg",
+              "download": "@@images/preview_image-4000-5496e5d01152aa6661428d9e264d3757.jpeg",
+              "filename": "GOPR9639.JPG",
+              "height": 3000,
+              "scales": Object {
+                "great": Object {
+                  "download": "@@images/preview_image-1200-0723c41835b6498e598780419cc25a4f.jpeg",
+                  "height": 900,
+                  "width": 1200,
+                },
+                "huge": Object {
+                  "download": "@@images/preview_image-1600-7c8256769b8c48d0392c6a51ef34a139.jpeg",
+                  "height": 1200,
+                  "width": 1600,
+                },
+                "icon": Object {
+                  "download": "@@images/preview_image-32-e743dcfb64ce39b0660285a04e7f842b.jpeg",
+                  "height": 24,
+                  "width": 32,
+                },
+                "large": Object {
+                  "download": "@@images/preview_image-800-b30bff7dbaa62fc6aca82639c9f5ee97.jpeg",
+                  "height": 600,
+                  "width": 800,
+                },
+                "larger": Object {
+                  "download": "@@images/preview_image-1000-e97d87c2a35fdc6262f429262854faed.jpeg",
+                  "height": 750,
+                  "width": 1000,
+                },
+                "mini": Object {
+                  "download": "@@images/preview_image-200-2a8af40b17e1f5562607a1cf876244b1.jpeg",
+                  "height": 150,
+                  "width": 200,
+                },
+                "preview": Object {
+                  "download": "@@images/preview_image-400-1a82684a51b55644eef2807c2761b711.jpeg",
+                  "height": 300,
+                  "width": 400,
+                },
+                "teaser": Object {
+                  "download": "@@images/preview_image-600-71895aac86b72d21dd0f2bad189871c3.jpeg",
+                  "height": 450,
+                  "width": 600,
+                },
+                "thumb": Object {
+                  "download": "@@images/preview_image-128-88f2831a9f099921f03d3244021b03ab.jpeg",
+                  "height": 96,
+                  "width": 128,
+                },
+                "tile": Object {
+                  "download": "@@images/preview_image-64-9ad26e8053451aec63586d66e111deb8.jpeg",
+                  "height": 48,
+                  "width": 64,
+                },
+              },
+              "size": 6446468,
+              "width": 4000,
+            },
+          ],
+        },
+      }
+    }
+    loading="eager"
+    sizes="100vw"
+    width="120"
+  />
+</a>
+`;

--- a/src/components/theme/SolrSearch/resultItems/helpers/__snapshots__/ResultItemPreviewImage.test.jsx.snap
+++ b/src/components/theme/SolrSearch/resultItems/helpers/__snapshots__/ResultItemPreviewImage.test.jsx.snap
@@ -1,5 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ResultItemPreviewImage legacy image if contentTypeSearchResultAlwaysUseLegacyImage is true 1`] = `
+<a
+  href="/testnews1"
+  onClick={[Function]}
+>
+  <a
+    href="/testnews1"
+    onClick={[Function]}
+  >
+    <img
+      className="foo"
+      height="130"
+      loading="eager"
+      src="/testnews1/@@images/preview_image-400-1a82684a51b55644eef2807c2761b711.jpeg"
+      width="120"
+    />
+  </a>
+</a>
+`;
+
+exports[`ResultItemPreviewImage legacy image if image component not available on Volto 16 1`] = `
+<a
+  href="/testnews1"
+  onClick={[Function]}
+>
+  <a
+    href="/testnews1"
+    onClick={[Function]}
+  >
+    <img
+      className="foo"
+      height="130"
+      loading="eager"
+      src="/testnews1/@@images/preview_image-400-1a82684a51b55644eef2807c2761b711.jpeg"
+      width="120"
+    />
+  </a>
+</a>
+`;
+
 exports[`ResultItemPreviewImage normal with default props 1`] = `
 <a
   href="/testnews1"

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,11 @@ const applyConfig = (config) => {
   config.views.contentTypeSearchResultDefaultView =
     searchResultItems.DefaultResultItem;
 
+  // The search results use the Volto Image component, unless it's not
+  // available, for example in Volto < 17. This flag, if set to true,
+  // forces the use of the legacy component in all cases.
+  config.settings.contentTypeSearchResultAlwaysUseLegacyImage = false;
+
   // Options for solr search which can be customized
   config.settings.solrSearchOptions = config.settings.solrSearchDefaultOptions = {
     searchAction: solrSearchContent,


### PR DESCRIPTION
Support all preview images

- preview image for news
- for all content types, if exist
- use volto's Image component

- add compatibility for Volto 16 (or less)

Update default icon