### PR TITLE
Use an icon per content type in the results

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,27 @@ Additionally. the `config.views.contentTypeSearchResultDefaultView` defines the 
     searchResultItems.DefaultResultItem;
 ```
 
+### Result type icons
+
+In addition to the result type templates, it's also possible to use which icon to use to represent any specific result icon.
+
+`config.settings.contentTypeSearchResultIcons` is a mapping from content type name to the icon to use for the content type. In addition, `config.settings.contentTypeSearchResultDefaultIcon` specifies a fallback to be used for any content type not found in the mapping (and functions as a default).
+
+config.settings.contentTypeSearchResultIcons is by default populated from `config.settings.contentIcons` which is usually the right thing to do. The following example uses these settings, but also defines specific icons for some specific content types.
+
+All supported content type templates respect these settings, so an icon for a content type can be redefined without the need to redefine the entire template, if otherwise no other changes are needed.
+
+```js
+  // Icon types. This will be in effect with all supported
+  // content type templates.
+  config.settings.contentTypeSearchResultIcons = {
+    ...config.settings.contentIcons,
+    Event: calendarSVG,
+    Image: imageSVG,
+    'News Item': newsSVG,
+  };
+  config.settings.contentTypeSearchResultDefaultIcon = fileSVG;
+```
 
 ### Other options
 

--- a/news/10.feature
+++ b/news/10.feature
@@ -1,0 +1,1 @@
+Improved result type icons configuration @reebalazs

--- a/src/components/theme/SolrSearch/resultItems/DefaultResultItem.jsx
+++ b/src/components/theme/SolrSearch/resultItems/DefaultResultItem.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import ResultItemDate, { thresholdDate } from './helpers/ResultItemDate';
-import { Icon } from '@plone/volto/components';
-import fileSVG from '@plone/volto/icons/file.svg';
 import ConcatChildren from './helpers/ConcatChildren';
 import ResultItemPreviewImage from './helpers/ResultItemPreviewImage';
+import IconForContentType from './helpers/IconForContentType';
 
 // import { FormattedMessage } from 'react-intl';
 
@@ -57,7 +56,7 @@ const DefaultResultItem = ({ item }) => (
           }
           if2={false}
         >
-          <Icon className="itemIcon" size="20px" name={fileSVG} />
+          <IconForContentType type={item['@type']} />
           <ResultItemDate
             date={item?.extras?.start ? item.extras.start : item?.effective}
           />

--- a/src/components/theme/SolrSearch/resultItems/EventResultItem.jsx
+++ b/src/components/theme/SolrSearch/resultItems/EventResultItem.jsx
@@ -3,8 +3,8 @@ import { Link } from 'react-router-dom';
 import { Icon } from '@plone/volto/components';
 import ResultItemDate from './helpers/ResultItemDate';
 import locationSVG from '../icons/location.svg';
-import calendarSVG from '@plone/volto/icons/calendar.svg';
 import ResultItemPreviewImage from './helpers/ResultItemPreviewImage';
+import IconForContentType from './helpers/IconForContentType';
 
 const EventResultItem = ({ item }) => (
   <article className="tileItem">
@@ -41,7 +41,7 @@ const EventResultItem = ({ item }) => (
     )}
     <div className="tileFooter">
       <div>
-        <Icon className="itemIcon" size="20px" name={calendarSVG} />
+        <IconForContentType type={item['@type']} />
         <ResultItemDate
           date={item?.extras?.start ? item.extras.start : item?.effective}
           showTime={true}

--- a/src/components/theme/SolrSearch/resultItems/ImageResultItem.jsx
+++ b/src/components/theme/SolrSearch/resultItems/ImageResultItem.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import ResultItemDate, { thresholdDate } from './helpers/ResultItemDate';
-import { Icon } from '@plone/volto/components';
-import imageSVG from '@plone/volto/icons/image.svg';
 import ConcatChildren from './helpers/ConcatChildren';
 import ImageType, { getImageType } from './helpers/ImageType';
 import ResultItemPreviewImage from './helpers/ResultItemPreviewImage';
+import IconForContentType from './helpers/IconForContentType';
 
 const ImageResultItem = ({ item }) => (
   <article className="tileItem">
@@ -49,7 +48,7 @@ const ImageResultItem = ({ item }) => (
           }
           if2={getImageType(item?.extras?.mime_type)}
         >
-          <Icon className="itemIcon" size="20px" name={imageSVG} />
+          <IconForContentType type={item['@type']} />
           <ImageType mimeType={item?.extras?.mime_type} />
           <ResultItemDate
             date={item?.extras?.start ? item.extras.start : item?.effective}

--- a/src/components/theme/SolrSearch/resultItems/NewsItemResultItem.jsx
+++ b/src/components/theme/SolrSearch/resultItems/NewsItemResultItem.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import ResultItemDate from './helpers/ResultItemDate';
-import { Icon } from '@plone/volto/components';
-import newsSVG from '@plone/volto/icons/news.svg';
 import ConcatChildren from './helpers/ConcatChildren';
 import ImageType, { getImageType } from './helpers/ImageType';
 import ResultItemPreviewImage from './helpers/ResultItemPreviewImage';
+import IconForContentType from './helpers/IconForContentType';
 
 const NewsItemResultItem = ({ item }) => (
   <article className="tileItem">
@@ -43,7 +42,7 @@ const NewsItemResultItem = ({ item }) => (
     <div className="tileFooter">
       {(item?.effective || item?.extras?.start) && (
         <ConcatChildren if1={getImageType(item?.extras?.mime_type)}>
-          <Icon className="itemIcon" size="20px" name={newsSVG} />
+          <IconForContentType type={item['@type']} />
           <ImageType mimeType={item?.extras?.mime_type} />
           <ResultItemDate
             date={item?.extras?.start ? item.extras.start : item?.effective}

--- a/src/components/theme/SolrSearch/resultItems/helpers/IconForContentType.jsx
+++ b/src/components/theme/SolrSearch/resultItems/helpers/IconForContentType.jsx
@@ -1,0 +1,15 @@
+import { Icon } from '@plone/volto/components';
+import config from '@plone/volto/registry';
+
+const IconForContentType = ({ type }) => (
+  <Icon
+    className="itemIcon"
+    size="20px"
+    name={
+      config.settings.contentTypeSearchResultIcons[type] ||
+      config.settings.contentTypeSearchResultDefaultIcon
+    }
+  />
+);
+
+export default IconForContentType;

--- a/src/components/theme/SolrSearch/resultItems/helpers/IconForContentType.test.jsx
+++ b/src/components/theme/SolrSearch/resultItems/helpers/IconForContentType.test.jsx
@@ -1,0 +1,43 @@
+import { create } from 'react-test-renderer';
+import IconForContentType from './IconForContentType';
+import config from '@plone/volto/registry';
+
+describe('IconForContentType', () => {
+  let origContentTypeSearchResultIcons;
+  let origContentTypeSearchResultDefaultIcon;
+
+  beforeEach(() => {
+    origContentTypeSearchResultIcons =
+      config.settings.contentTypeSearchResultIcons;
+    origContentTypeSearchResultDefaultIcon =
+      config.settings.contentTypeSearchResultDefaultIcon;
+    config.settings.contentTypeSearchResultIcons = {
+      Event: { content: `calendarSVG` },
+      Image: { content: `imageSVG` },
+    };
+    config.settings.contentTypeSearchResultDefaultIcon = { content: 'fileSVG' };
+  });
+
+  afterEach(() => {
+    config.settings.contentTypeSearchResultIcons = origContentTypeSearchResultIcons;
+    config.settings.contentTypeSearchResultDefaultIcon = origContentTypeSearchResultDefaultIcon;
+  });
+
+  test('default icon', () => {
+    const component = create(<IconForContentType type={'Foo'} />);
+    const rendered = component.toJSON();
+    expect(rendered).toMatchSnapshot();
+  });
+
+  test('Event icon', () => {
+    const component = create(<IconForContentType type={'Event'} />);
+    const rendered = component.toJSON();
+    expect(rendered).toMatchSnapshot();
+  });
+
+  test('Image icon', () => {
+    const component = create(<IconForContentType type={'Image'} />);
+    const rendered = component.toJSON();
+    expect(rendered).toMatchSnapshot();
+  });
+});

--- a/src/components/theme/SolrSearch/resultItems/helpers/__snapshots__/IconForContentType.test.jsx.snap
+++ b/src/components/theme/SolrSearch/resultItems/helpers/__snapshots__/IconForContentType.test.jsx.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IconForContentType Event icon 1`] = `
+<svg
+  className="icon itemIcon"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "calendarSVG",
+    }
+  }
+  onClick={null}
+  style={
+    Object {
+      "fill": "currentColor",
+      "height": "20px",
+      "width": "auto",
+    }
+  }
+/>
+`;
+
+exports[`IconForContentType Image icon 1`] = `
+<svg
+  className="icon itemIcon"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "imageSVG",
+    }
+  }
+  onClick={null}
+  style={
+    Object {
+      "fill": "currentColor",
+      "height": "20px",
+      "width": "auto",
+    }
+  }
+/>
+`;
+
+exports[`IconForContentType default icon 1`] = `
+<svg
+  className="icon itemIcon"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "fileSVG",
+    }
+  }
+  onClick={null}
+  style={
+    Object {
+      "fill": "currentColor",
+      "height": "20px",
+      "width": "auto",
+    }
+  }
+/>
+`;

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import {
   SolrFormattedDate,
 } from '@kitconcept/volto-solr/components';
 import * as searchResultItems from '@kitconcept/volto-solr/components/theme/SolrSearch/resultItems';
+import fileSVG from '@plone/volto/icons/file.svg';
 import reducers from './reducers';
 import routes from './routes';
 import './theme/solrsearch.less';
@@ -36,6 +37,14 @@ const applyConfig = (config) => {
   // available, for example in Volto < 17. This flag, if set to true,
   // forces the use of the legacy component in all cases.
   config.settings.contentTypeSearchResultAlwaysUseLegacyImage = false;
+
+  // Icon types. This will be in effect with all supported
+  // content type templates. By default the content icons settings are
+  // used, but this can be overridden.
+  config.settings.contentTypeSearchResultIcons = {
+    ...config.settings.contentIcons,
+  };
+  config.settings.contentTypeSearchResultDefaultIcon = fileSVG;
 
   // Options for solr search which can be customized
   config.settings.solrSearchOptions = config.settings.solrSearchDefaultOptions = {


### PR DESCRIPTION
- add component for icons
- add support for setting up content icons from the Volto config