### PR TITLE
Send solr request only once [#19]

### DIFF
--- a/news/19.bugfix
+++ b/news/19.bugfix
@@ -1,0 +1,1 @@
+Send solr request only once [#25] @reebalazs

--- a/src/components/theme/SolrSearch/SolrSearch.jsx
+++ b/src/components/theme/SolrSearch/SolrSearch.jsx
@@ -239,7 +239,6 @@ class SolrSearch extends Component {
   };
 
   updateSearch = () => {
-    this.doSearch(this.searchParams());
     this.props.history.replace({
       search: qs.stringify(queryStateToParams(this.state)),
     });
@@ -247,7 +246,9 @@ class SolrSearch extends Component {
 
   handleQueryPaginationChange = (e, { activePage }) => {
     window.scrollTo(0, 0);
-    this.setState({ currentPage: activePage }, () => this.updateSearch());
+    this.setState({ currentPage: activePage }, () =>
+      this.doSearch(this.searchParams()),
+    );
   };
 
   onSortChange = (selectedOption, selectedSortOrder) => {


### PR DESCRIPTION
The solr request to the backend is sent 2 times. This fixes it and only 1 is sent.

By the way, this triggered a bug in asyncconnect. There was a race condition and sometimes the results will be ignored completely, that is both of the two updates were ignored.

It's beyond the scope to fix asyncconnect, but sending only 1 request instead of the double should fix this.