### PR TITLE
Suggestions and spellchecking, highlighting

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -26,7 +26,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Enable corepack
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest
+          corepack enable
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -27,7 +27,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Enable corepack
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest
+          corepack enable
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -25,7 +25,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Enable corepack
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest
+          corepack enable
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -25,7 +25,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Enable corepack
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest
+          corepack enable
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -27,7 +27,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Enable corepack
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest
+          corepack enable
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -25,7 +25,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Enable corepack
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest
+          corepack enable
 
       - name: Get pnpm store directory
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ GIT_FOLDER=$(CURRENT_DIR)/.git
 PRE_COMMIT=pipx run --spec 'pre-commit==3.7.1' pre-commit
 
 PLONE_VERSION=6
-VOLTO_VERSION=18.2.3
+VOLTO_VERSION=18.9.1
 DOCKER_IMAGE=plone/server-dev:${PLONE_VERSION}
 DOCKER_IMAGE_ACCEPTANCE=plone/server-acceptance:${PLONE_VERSION}
 
@@ -133,13 +133,13 @@ acceptance-install: ## Install Cypress, build containers
 acceptance-frontend-dev-start: ## Start acceptance frontend in development mode
     # Note the error is that :3001 gives an empty response from a cypress browser.
 	# Also see https://github.com/cypress-io/cypress/issues/27962
-	RAZZLE_API_PATH=http://127.0.0.1:55001/plone NODE_OPTIONS=--dns-result-order=ipv4first pnpm start
+	RAZZLE_API_PATH=http://localhost:55001/plone NODE_OPTIONS=--dns-result-order=ipv4first pnpm start
 
 .PHONY: acceptance-frontend-prod-start
 acceptance-frontend-prod-start: ## Start acceptance frontend in production mode
-# Note the error is that :3001 gives an empty response from a cypress browser.
+    # Note the error is that :3001 gives an empty response from a cypress browser.
 	# Also see https://github.com/cypress-io/cypress/issues/27962
-	RAZZLE_API_PATH=http://127.0.0.1:55001/plone NODE_OPTIONS=--dns-result-order=ipv4first pnpm build && pnpm start:prod
+	RAZZLE_API_PATH=http://localhost:55001/plone NODE_OPTIONS=--dns-result-order=ipv4first pnpm build && pnpm start:prod
 
 .PHONY: acceptance-backend-start
 acceptance-backend-start: ## Start backend acceptance server

--- a/acceptance/docker-compose.yml
+++ b/acceptance/docker-compose.yml
@@ -1,4 +1,47 @@
 services:
+  addon-dev:
+    build:
+      context: ../
+      dockerfile: ./dockerfiles/Dockerfile.acceptance
+      args:
+        ADDON_NAME: '${ADDON_NAME}'
+        ADDON_PATH: '${ADDON_PATH}'
+        VOLTO_VERSION: ${VOLTO_VERSION:-16}
+    volumes:
+      - ${CURRENT_DIR}:/app/src/addons/${ADDON_PATH}/
+    environment:
+      RAZZLE_INTERNAL_API_PATH: http://backend-acceptance:55001/plone
+      RAZZLE_API_PATH: http://localhost:55001/plone
+      # Note the error is that :3001 gives an empty response from a cypress browser.
+      # Also see https://github.com/cypress-io/cypress/issues/27962
+      NODE_OPTIONS: --dns-result-order=ipv4first
+      # HOST: 0.0.0.0
+    ports:
+      - 3000:3000
+      - 3001:3001
+    depends_on:
+      - backend-acceptance
+    profiles:
+      - dev
+
+  addon-acceptance:
+    build:
+      context: ../
+      dockerfile: ./dockerfiles/Dockerfile
+      args:
+        ADDON_NAME: '${ADDON_NAME}'
+        ADDON_PATH: '${ADDON_PATH}'
+        VOLTO_VERSION: ${VOLTO_VERSION:-16}
+    volumes:
+      - ${CURRENT_DIR}:/app/src/addons/${ADDON_PATH}/
+    environment:
+      RAZZLE_INTERNAL_API_PATH: http://backend-acceptance:55001/plone
+      RAZZLE_API_PATH: http://localhost:55001/plone
+    ports:
+      - 3000:3000
+    depends_on:
+      - backend-acceptance
+
   backend-acceptance:
     image: plone/plone-backend:${PLONE_VERSION:-6}
     command: ./bin/robot-server plone.app.robotframework.testing.VOLTO_ROBOT_TESTING
@@ -8,8 +51,8 @@ services:
       # Use plone.volto rather than kitconcept.volto for the acceptance
       # testing, which makes login in tests "more conventional". - otherwise
       # it's no difference, both could make sense.
-      ADDONS: 'plone.app.robotframework==2.0.0 plone.app.contenttypes plone.restapi plone.volto kitconcept.solr==1.0.0a5'
-      APPLY_PROFILES: plone.app.contenttypes:plone-content,plone.restapi:default,plone.volto:default-homepage,kitconcept.solr:default,collective.solr:default
+      ADDONS: 'plone.app.robotframework==2.0.0 plone.app.contenttypes plone.restapi plone.volto kitconcept.solr@git+https://github.com/kitconcept/kitconcept.solr.git@fhnw-develop'
+      APPLY_PROFILES: plone.app.contenttypes:plone-content,plone.restapi:default,plone.volto:default,kitconcept.solr:default,collective.solr:default
       CONFIGURE_PACKAGES: plone.app.contenttypes,plone.restapi,plone.volto,plone.volto.cors,kitconcept.solr,collective.solr
       SOLR_HOST: solr-acceptance
       SOLR_PORT: 8983

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -9,16 +9,18 @@ COPY --chown=node:node ./ /app/src/addons/${ADDON_PATH}/
 
 RUN <<EOT
     /setupAddon
-    yarn install --network-timeout 1000000
-    yarn build
-    rm -rf cache omelette .yarn/cache
+    npm install -g corepack@latest
+    corepack enable
+    pnpm install --fetch-timeout 1000000
+    pnpm build
+    rm -rf cache omelette `pnpm store path --silent`
 EOT
 
 FROM plone/frontend-prod-config:${VOLTO_VERSION}
 
 LABEL maintainer="Plone Community <dev@plone.org>" \
-      org.label-schema.name="volto-solr" \
-      org.label-schema.description="Solr front-end support for Volto" \
-      org.label-schema.vendor="Plone Foundation"
+    org.label-schema.name="volto-solr" \
+    org.label-schema.description="Solr front-end support for Volto" \
+    org.label-schema.vendor="Plone Foundation"
 
 COPY --from=builder /app/ /app/

--- a/dockerfiles/Dockerfile.acceptance
+++ b/dockerfiles/Dockerfile.acceptance
@@ -9,5 +9,8 @@ COPY --chown=node:node package.json /app/src/addons/${ADDON_PATH}/
 
 RUN <<EOT
     /setupAddon
-    yarn install --network-timeout 1000000
+    npm install -g corepack@latest
+    corepack enable
+    pnpm install --fetch-timeout 1000000
+    pnpm build
 EOT

--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -9,5 +9,9 @@ COPY --chown=node:node package.json /app/src/addons/${ADDON_PATH}/
 
 RUN <<EOT
     /setupAddon
-    yarn install --network-timeout 1000000
+    npm install -g corepack@latest
+    corepack enable
+    pnpm install --fetch-timeout 1000000
+    pnpm build
+    rm -rf cache omelette `pnpm store path --silent`
 EOT

--- a/packages/volto-solr/locales/de/LC_MESSAGES/volto.po
+++ b/packages/volto-solr/locales/de/LC_MESSAGES/volto.po
@@ -10,3 +10,157 @@ msgstr ""
 "Content-Type: \n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. Default: "All"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "All"
+msgstr ""
+
+#. Default: "Alphabetically"
+#: components/theme/SolrSearch/SelectSorting
+#: reducers/index
+msgid "Alphabetically"
+msgstr ""
+
+#. Default: "Date (newest first)"
+#: components/theme/SolrSearch/SelectSorting
+#: reducers/index
+msgid "Date (newest first)"
+msgstr ""
+
+#. Default: "Events"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Events"
+msgstr ""
+
+#. Default: "Files"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Files"
+msgstr ""
+
+#. Default: "Images"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Images"
+msgstr ""
+
+#. Default: "Job offers"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Job offers"
+msgstr ""
+
+#. Default: "Layout:"
+#: components/theme/SolrSearch/SelectLayout
+msgid "Layout:"
+msgstr ""
+
+#. Default: "Open a Mailto Link to the Members Email Address"
+#: components/theme/SolrSearchWidget/MailTo
+msgid "Open a Mailto Link to the Members Email Address"
+msgstr ""
+
+#. Default: "Pages"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Pages"
+msgstr ""
+
+#. Default: "People"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "People"
+msgstr ""
+
+#. Default: "Relevance"
+#: components/theme/SolrSearch/SelectSorting
+#: reducers/index
+msgid "Relevance"
+msgstr ""
+
+#. Default: "Reports"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Reports"
+msgstr ""
+
+#. Default: "Search"
+#: components/theme/SolrSearch/SolrSearch
+#: components/theme/SolrSearchWidget/SolrSearchWidget
+msgid "Search"
+msgstr ""
+
+#. Default: "Search Site"
+#: components/theme/SolrSearchWidget/SolrSearchWidget
+msgid "Search Site"
+msgstr ""
+
+#. Default: "Search..."
+#: components/theme/SolrSearch/SearchConditionsFieldSearch
+#: components/theme/SolrSearch/SolrSearch
+msgid "Search..."
+msgstr ""
+
+#. Default: "Select…"
+#: components/theme/SolrSearch/SelectSorting
+#: reducers/index
+msgid "Select…"
+msgstr ""
+
+#. Default: "Show all search results..."
+#: components/theme/SolrSearchWidget/SolrSearchWidget
+msgid "Show all search results..."
+msgstr ""
+
+#. Default: "Show less"
+#: components/theme/SolrSearch/ShowMoreIndicator
+msgid "Show less"
+msgstr ""
+
+#. Default: "Show more"
+#: components/theme/SolrSearch/ShowMoreIndicator
+msgid "Show more"
+msgstr ""
+
+#. Default: "Sort by:"
+#: components/theme/SolrSearch/SelectSorting
+#: reducers/index
+msgid "Sort By:"
+msgstr ""
+
+#. Default: "Loading"
+#: components/theme/SolrSearch/SolrSearch
+msgid "loading"
+msgstr ""
+
+#. Default: "not published yet"
+#: components/theme/SolrSearch/resultItems/helpers/ResultItemDate
+msgid "not published yet"
+msgstr ""
+
+#. Default: "results"
+#: components/theme/SolrSearch/SolrSearch
+msgid "results"
+msgstr ""
+
+#. Default: "All content (global)"
+#: components/theme/SolrSearch/SolrSearch
+msgid "searchGlobalized"
+msgstr ""
+
+#. Default: "This subfolder only"
+#: components/theme/SolrSearch/SolrSearch
+msgid "searchLocalized"
+msgstr ""
+
+#. Default: "Show results for:"
+#: components/theme/SolrSearch/SolrSearch
+msgid "searchLocalizedLabel"
+msgstr ""
+
+#. Default: "{total, plural, =0 {No results} =1 {# result} other {# results}}"
+#: components/theme/SolrSearch/SearchResultInfo
+#: reducers/index
+msgid "{total, plural, =0 {No results} =1 {# result} other {# results}}"
+msgstr ""
+
+#. Default: "{total, plural, =0 {No results} =1 {# result} other {# results}} for"
+#: components/theme/SolrSearch/SearchResultInfo
+#: reducers/index
+msgid "{total, plural, =0 {No results} =1 {# result} other {# results}} for"
+msgstr ""

--- a/packages/volto-solr/locales/en/LC_MESSAGES/volto.po
+++ b/packages/volto-solr/locales/en/LC_MESSAGES/volto.po
@@ -10,3 +10,157 @@ msgstr ""
 "Content-Type: \n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. Default: "All"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "All"
+msgstr ""
+
+#. Default: "Alphabetically"
+#: components/theme/SolrSearch/SelectSorting
+#: reducers/index
+msgid "Alphabetically"
+msgstr ""
+
+#. Default: "Date (newest first)"
+#: components/theme/SolrSearch/SelectSorting
+#: reducers/index
+msgid "Date (newest first)"
+msgstr ""
+
+#. Default: "Events"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Events"
+msgstr ""
+
+#. Default: "Files"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Files"
+msgstr ""
+
+#. Default: "Images"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Images"
+msgstr ""
+
+#. Default: "Job offers"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Job offers"
+msgstr ""
+
+#. Default: "Layout:"
+#: components/theme/SolrSearch/SelectLayout
+msgid "Layout:"
+msgstr ""
+
+#. Default: "Open a Mailto Link to the Members Email Address"
+#: components/theme/SolrSearchWidget/MailTo
+msgid "Open a Mailto Link to the Members Email Address"
+msgstr ""
+
+#. Default: "Pages"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Pages"
+msgstr ""
+
+#. Default: "People"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "People"
+msgstr ""
+
+#. Default: "Relevance"
+#: components/theme/SolrSearch/SelectSorting
+#: reducers/index
+msgid "Relevance"
+msgstr ""
+
+#. Default: "Reports"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Reports"
+msgstr ""
+
+#. Default: "Search"
+#: components/theme/SolrSearch/SolrSearch
+#: components/theme/SolrSearchWidget/SolrSearchWidget
+msgid "Search"
+msgstr ""
+
+#. Default: "Search Site"
+#: components/theme/SolrSearchWidget/SolrSearchWidget
+msgid "Search Site"
+msgstr ""
+
+#. Default: "Search..."
+#: components/theme/SolrSearch/SearchConditionsFieldSearch
+#: components/theme/SolrSearch/SolrSearch
+msgid "Search..."
+msgstr ""
+
+#. Default: "Select…"
+#: components/theme/SolrSearch/SelectSorting
+#: reducers/index
+msgid "Select…"
+msgstr ""
+
+#. Default: "Show all search results..."
+#: components/theme/SolrSearchWidget/SolrSearchWidget
+msgid "Show all search results..."
+msgstr ""
+
+#. Default: "Show less"
+#: components/theme/SolrSearch/ShowMoreIndicator
+msgid "Show less"
+msgstr ""
+
+#. Default: "Show more"
+#: components/theme/SolrSearch/ShowMoreIndicator
+msgid "Show more"
+msgstr ""
+
+#. Default: "Sort by:"
+#: components/theme/SolrSearch/SelectSorting
+#: reducers/index
+msgid "Sort By:"
+msgstr ""
+
+#. Default: "Loading"
+#: components/theme/SolrSearch/SolrSearch
+msgid "loading"
+msgstr ""
+
+#. Default: "not published yet"
+#: components/theme/SolrSearch/resultItems/helpers/ResultItemDate
+msgid "not published yet"
+msgstr ""
+
+#. Default: "results"
+#: components/theme/SolrSearch/SolrSearch
+msgid "results"
+msgstr ""
+
+#. Default: "All content (global)"
+#: components/theme/SolrSearch/SolrSearch
+msgid "searchGlobalized"
+msgstr ""
+
+#. Default: "This subfolder only"
+#: components/theme/SolrSearch/SolrSearch
+msgid "searchLocalized"
+msgstr ""
+
+#. Default: "Show results for:"
+#: components/theme/SolrSearch/SolrSearch
+msgid "searchLocalizedLabel"
+msgstr ""
+
+#. Default: "{total, plural, =0 {No results} =1 {# result} other {# results}}"
+#: components/theme/SolrSearch/SearchResultInfo
+#: reducers/index
+msgid "{total, plural, =0 {No results} =1 {# result} other {# results}}"
+msgstr ""
+
+#. Default: "{total, plural, =0 {No results} =1 {# result} other {# results}} for"
+#: components/theme/SolrSearch/SearchResultInfo
+#: reducers/index
+msgid "{total, plural, =0 {No results} =1 {# result} other {# results}} for"
+msgstr ""

--- a/packages/volto-solr/locales/es/LC_MESSAGES/volto.po
+++ b/packages/volto-solr/locales/es/LC_MESSAGES/volto.po
@@ -17,3 +17,157 @@ msgstr ""
 "Domain: volto\n"
 "X-Is-Fallback-For: es-ar es-bo es-cl es-co es-cr es-do es-ec es-es es-sv es-gt es-hn es-mx es-ni es-pa es-py es-pe es-pr es-us es-uy es-ve\n"
 "X-Generator: Poedit 2.2.1\n"
+
+#. Default: "All"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "All"
+msgstr ""
+
+#. Default: "Alphabetically"
+#: components/theme/SolrSearch/SelectSorting
+#: reducers/index
+msgid "Alphabetically"
+msgstr ""
+
+#. Default: "Date (newest first)"
+#: components/theme/SolrSearch/SelectSorting
+#: reducers/index
+msgid "Date (newest first)"
+msgstr ""
+
+#. Default: "Events"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Events"
+msgstr ""
+
+#. Default: "Files"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Files"
+msgstr ""
+
+#. Default: "Images"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Images"
+msgstr ""
+
+#. Default: "Job offers"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Job offers"
+msgstr ""
+
+#. Default: "Layout:"
+#: components/theme/SolrSearch/SelectLayout
+msgid "Layout:"
+msgstr ""
+
+#. Default: "Open a Mailto Link to the Members Email Address"
+#: components/theme/SolrSearchWidget/MailTo
+msgid "Open a Mailto Link to the Members Email Address"
+msgstr ""
+
+#. Default: "Pages"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Pages"
+msgstr ""
+
+#. Default: "People"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "People"
+msgstr ""
+
+#. Default: "Relevance"
+#: components/theme/SolrSearch/SelectSorting
+#: reducers/index
+msgid "Relevance"
+msgstr ""
+
+#. Default: "Reports"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Reports"
+msgstr ""
+
+#. Default: "Search"
+#: components/theme/SolrSearch/SolrSearch
+#: components/theme/SolrSearchWidget/SolrSearchWidget
+msgid "Search"
+msgstr ""
+
+#. Default: "Search Site"
+#: components/theme/SolrSearchWidget/SolrSearchWidget
+msgid "Search Site"
+msgstr ""
+
+#. Default: "Search..."
+#: components/theme/SolrSearch/SearchConditionsFieldSearch
+#: components/theme/SolrSearch/SolrSearch
+msgid "Search..."
+msgstr ""
+
+#. Default: "Select…"
+#: components/theme/SolrSearch/SelectSorting
+#: reducers/index
+msgid "Select…"
+msgstr ""
+
+#. Default: "Show all search results..."
+#: components/theme/SolrSearchWidget/SolrSearchWidget
+msgid "Show all search results..."
+msgstr ""
+
+#. Default: "Show less"
+#: components/theme/SolrSearch/ShowMoreIndicator
+msgid "Show less"
+msgstr ""
+
+#. Default: "Show more"
+#: components/theme/SolrSearch/ShowMoreIndicator
+msgid "Show more"
+msgstr ""
+
+#. Default: "Sort by:"
+#: components/theme/SolrSearch/SelectSorting
+#: reducers/index
+msgid "Sort By:"
+msgstr ""
+
+#. Default: "Loading"
+#: components/theme/SolrSearch/SolrSearch
+msgid "loading"
+msgstr ""
+
+#. Default: "not published yet"
+#: components/theme/SolrSearch/resultItems/helpers/ResultItemDate
+msgid "not published yet"
+msgstr ""
+
+#. Default: "results"
+#: components/theme/SolrSearch/SolrSearch
+msgid "results"
+msgstr ""
+
+#. Default: "All content (global)"
+#: components/theme/SolrSearch/SolrSearch
+msgid "searchGlobalized"
+msgstr ""
+
+#. Default: "This subfolder only"
+#: components/theme/SolrSearch/SolrSearch
+msgid "searchLocalized"
+msgstr ""
+
+#. Default: "Show results for:"
+#: components/theme/SolrSearch/SolrSearch
+msgid "searchLocalizedLabel"
+msgstr ""
+
+#. Default: "{total, plural, =0 {No results} =1 {# result} other {# results}}"
+#: components/theme/SolrSearch/SearchResultInfo
+#: reducers/index
+msgid "{total, plural, =0 {No results} =1 {# result} other {# results}}"
+msgstr ""
+
+#. Default: "{total, plural, =0 {No results} =1 {# result} other {# results}} for"
+#: components/theme/SolrSearch/SearchResultInfo
+#: reducers/index
+msgid "{total, plural, =0 {No results} =1 {# result} other {# results}} for"
+msgstr ""

--- a/packages/volto-solr/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/packages/volto-solr/locales/pt_BR/LC_MESSAGES/volto.po
@@ -15,3 +15,157 @@ msgstr ""
 "Language-Name: Português do Brasil\n"
 "Preferred-Encodings: utf-8\n"
 "Domain: volto\n"
+
+#. Default: "All"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "All"
+msgstr ""
+
+#. Default: "Alphabetically"
+#: components/theme/SolrSearch/SelectSorting
+#: reducers/index
+msgid "Alphabetically"
+msgstr ""
+
+#. Default: "Date (newest first)"
+#: components/theme/SolrSearch/SelectSorting
+#: reducers/index
+msgid "Date (newest first)"
+msgstr ""
+
+#. Default: "Events"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Events"
+msgstr ""
+
+#. Default: "Files"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Files"
+msgstr ""
+
+#. Default: "Images"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Images"
+msgstr ""
+
+#. Default: "Job offers"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Job offers"
+msgstr ""
+
+#. Default: "Layout:"
+#: components/theme/SolrSearch/SelectLayout
+msgid "Layout:"
+msgstr ""
+
+#. Default: "Open a Mailto Link to the Members Email Address"
+#: components/theme/SolrSearchWidget/MailTo
+msgid "Open a Mailto Link to the Members Email Address"
+msgstr ""
+
+#. Default: "Pages"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Pages"
+msgstr ""
+
+#. Default: "People"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "People"
+msgstr ""
+
+#. Default: "Relevance"
+#: components/theme/SolrSearch/SelectSorting
+#: reducers/index
+msgid "Relevance"
+msgstr ""
+
+#. Default: "Reports"
+#: components/theme/SolrSearch/solr-facets-i18n
+msgid "Reports"
+msgstr ""
+
+#. Default: "Search"
+#: components/theme/SolrSearch/SolrSearch
+#: components/theme/SolrSearchWidget/SolrSearchWidget
+msgid "Search"
+msgstr ""
+
+#. Default: "Search Site"
+#: components/theme/SolrSearchWidget/SolrSearchWidget
+msgid "Search Site"
+msgstr ""
+
+#. Default: "Search..."
+#: components/theme/SolrSearch/SearchConditionsFieldSearch
+#: components/theme/SolrSearch/SolrSearch
+msgid "Search..."
+msgstr ""
+
+#. Default: "Select…"
+#: components/theme/SolrSearch/SelectSorting
+#: reducers/index
+msgid "Select…"
+msgstr ""
+
+#. Default: "Show all search results..."
+#: components/theme/SolrSearchWidget/SolrSearchWidget
+msgid "Show all search results..."
+msgstr ""
+
+#. Default: "Show less"
+#: components/theme/SolrSearch/ShowMoreIndicator
+msgid "Show less"
+msgstr ""
+
+#. Default: "Show more"
+#: components/theme/SolrSearch/ShowMoreIndicator
+msgid "Show more"
+msgstr ""
+
+#. Default: "Sort by:"
+#: components/theme/SolrSearch/SelectSorting
+#: reducers/index
+msgid "Sort By:"
+msgstr ""
+
+#. Default: "Loading"
+#: components/theme/SolrSearch/SolrSearch
+msgid "loading"
+msgstr ""
+
+#. Default: "not published yet"
+#: components/theme/SolrSearch/resultItems/helpers/ResultItemDate
+msgid "not published yet"
+msgstr ""
+
+#. Default: "results"
+#: components/theme/SolrSearch/SolrSearch
+msgid "results"
+msgstr ""
+
+#. Default: "All content (global)"
+#: components/theme/SolrSearch/SolrSearch
+msgid "searchGlobalized"
+msgstr ""
+
+#. Default: "This subfolder only"
+#: components/theme/SolrSearch/SolrSearch
+msgid "searchLocalized"
+msgstr ""
+
+#. Default: "Show results for:"
+#: components/theme/SolrSearch/SolrSearch
+msgid "searchLocalizedLabel"
+msgstr ""
+
+#. Default: "{total, plural, =0 {No results} =1 {# result} other {# results}}"
+#: components/theme/SolrSearch/SearchResultInfo
+#: reducers/index
+msgid "{total, plural, =0 {No results} =1 {# result} other {# results}}"
+msgstr ""
+
+#. Default: "{total, plural, =0 {No results} =1 {# result} other {# results}} for"
+#: components/theme/SolrSearch/SearchResultInfo
+#: reducers/index
+msgid "{total, plural, =0 {No results} =1 {# result} other {# results}} for"
+msgstr ""

--- a/packages/volto-solr/src/components/theme/SolrSearch/getCollationMisspellings.js
+++ b/packages/volto-solr/src/components/theme/SolrSearch/getCollationMisspellings.js
@@ -1,0 +1,7 @@
+export const getCollationMisspellings = (collationMisspellings) =>
+  Object.fromEntries(
+    Array.from(
+      { length: Math.floor((collationMisspellings?.length ?? 0) / 2) },
+      (_, i) => collationMisspellings.slice(i * 2, i * 2 + 2),
+    ),
+  );

--- a/packages/volto-solr/src/components/theme/SolrSearch/getCollationMisspellings.test.js
+++ b/packages/volto-solr/src/components/theme/SolrSearch/getCollationMisspellings.test.js
@@ -1,0 +1,31 @@
+import { getCollationMisspellings } from './getCollationMisspellings';
+
+describe('getCollationMisspellings', () => {
+  it('should return empty object for empty/null/undefined input', () => {
+    expect(getCollationMisspellings([])).toEqual({});
+    expect(getCollationMisspellings(null)).toEqual({});
+    expect(getCollationMisspellings(undefined)).toEqual({});
+  });
+
+  it('should handle single misspelling pair', () => {
+    const input = ['color', 'colour'];
+    expect(getCollationMisspellings(input)).toEqual({
+      color: 'colour',
+    });
+  });
+
+  it('should handle multiple misspelling pairs', () => {
+    const input = ['color', 'colour', 'behavior', 'behaviour'];
+    expect(getCollationMisspellings(input)).toEqual({
+      color: 'colour',
+      behavior: 'behaviour',
+    });
+  });
+
+  it('should ignore last element when array length is odd', () => {
+    const input = ['color', 'colour', 'behavior'];
+    expect(getCollationMisspellings(input)).toEqual({
+      color: 'colour',
+    });
+  });
+});

--- a/packages/volto-solr/src/components/theme/SolrSearch/getSuggestions.js
+++ b/packages/volto-solr/src/components/theme/SolrSearch/getSuggestions.js
@@ -1,0 +1,20 @@
+const concat = (a) => [].concat(...a);
+
+export const getSuggestions = (suggestions, options = {}) => {
+  const maxLength = options?.maxLength ?? 4;
+  const getter = options?.getter ?? ((i) => i.word);
+  const sorter = options?.sorter ?? ((a, b) => b.freq - a.freq);
+  return concat(
+    suggestions
+      .filter((_, index) => index % 2 === 1)
+      .map((suggestionItem) => suggestionItem.suggestion),
+  )
+    .sort((a, b) => getter(a)?.localeCompare(getter(b)))
+    .filter(function (item, pos, ary) {
+      const word = getter(item);
+      return word && (!pos || word !== getter(ary[pos - 1]));
+    })
+    .sort(sorter)
+    .map((item) => getter(item))
+    .slice(0, maxLength);
+};

--- a/packages/volto-solr/src/components/theme/SolrSearch/getSuggestions.test.js
+++ b/packages/volto-solr/src/components/theme/SolrSearch/getSuggestions.test.js
@@ -1,0 +1,206 @@
+import { getSuggestions } from './getSuggestions';
+
+describe('getSuggestions', () => {
+  it('should return empty array for empty input', () => {
+    expect(getSuggestions([])).toEqual([]);
+  });
+
+  it('works', () => {
+    const input = [
+      'ba',
+      {
+        suggestion: [
+          { freq: 1, word: 'bar' },
+          { freq: 1, word: 'banana' },
+        ],
+      },
+      'ap',
+      {
+        suggestion: [
+          { freq: 1, word: 'api' },
+          { freq: 1, word: 'apple' },
+        ],
+      },
+    ];
+    expect(getSuggestions(input)).toEqual(['api', 'apple', 'banana', 'bar']);
+  });
+
+  it('sorted by default freq', () => {
+    const input = [
+      'ba',
+      {
+        suggestion: [
+          { freq: 1, word: 'bar' },
+          { freq: 2, word: 'banana' },
+        ],
+      },
+      'ap',
+      {
+        suggestion: [
+          { freq: 1, word: 'api' },
+          { freq: 3, word: 'apple' },
+        ],
+      },
+    ];
+    expect(getSuggestions(input)).toEqual(['apple', 'banana', 'api', 'bar']);
+  });
+
+  it('sorted by custom function', () => {
+    const input = [
+      'ba',
+      {
+        suggestion: [
+          { freq: 1, word: 'bar' },
+          { freq: 2, word: 'banana' },
+        ],
+      },
+      'ap',
+      {
+        suggestion: [
+          { freq: 1, word: 'api' },
+          { freq: 3, word: 'apple' },
+        ],
+      },
+    ];
+    expect(getSuggestions(input)).toEqual(['apple', 'banana', 'api', 'bar']);
+  });
+
+  it('custom sorter function', () => {
+    const input = [
+      'ba',
+      {
+        suggestion: [
+          { customfreq: 1, word: 'bar' },
+          { customfreq: 2, word: 'banana' },
+        ],
+      },
+      'ap',
+      {
+        suggestion: [
+          { customfreq: 1, word: 'api' },
+          { customfreq: 3, word: 'apple' },
+        ],
+      },
+    ];
+    expect(
+      getSuggestions(input, { sorter: (a, b) => b.customfreq - a.customfreq }),
+    ).toEqual(['apple', 'banana', 'api', 'bar']);
+  });
+
+  it('custom getter option', () => {
+    const input = [
+      'ba',
+      {
+        suggestion: [
+          { freq: 1, customword: 'bar' },
+          { freq: 1, customword: 'banana' },
+        ],
+      },
+      'ap',
+      {
+        suggestion: [
+          { freq: 1, customword: 'api' },
+          { freq: 1, customword: 'apple' },
+        ],
+      },
+    ];
+    expect(getSuggestions(input, { getter: (i) => i.customword })).toEqual([
+      'api',
+      'apple',
+      'banana',
+      'bar',
+    ]);
+  });
+
+  it('getter returns undefined', () => {
+    const input = [
+      'ba',
+      {
+        suggestion: [{ freq: 1 }, { freq: 2 }],
+      },
+      'ap',
+      {
+        suggestion: [
+          { freq: 1, word: 'api' },
+          { freq: 3, word: 'apple' },
+        ],
+      },
+    ];
+    expect(getSuggestions(input)).toEqual(['apple', 'api']);
+  });
+
+  it('maxLength option', () => {
+    const input = [
+      'ba',
+      {
+        suggestion: [
+          { freq: 1, word: 'bar' },
+          { freq: 1, word: 'banana' },
+        ],
+      },
+      'ap',
+      {
+        suggestion: [
+          { freq: 1, word: 'api' },
+          { freq: 1, word: 'apple' },
+        ],
+      },
+    ];
+    expect(getSuggestions(input, { maxLength: 5 })).toEqual([
+      'api',
+      'apple',
+      'banana',
+      'bar',
+    ]);
+    expect(getSuggestions(input, { maxLength: 4 })).toEqual([
+      'api',
+      'apple',
+      'banana',
+      'bar',
+    ]);
+    expect(getSuggestions(input, { maxLength: 3 })).toEqual([
+      'api',
+      'apple',
+      'banana',
+    ]);
+    expect(getSuggestions(input, { maxLength: 2 })).toEqual(['api', 'apple']);
+    expect(getSuggestions(input, { maxLength: 1 })).toEqual(['api']);
+  });
+
+  it('removes duplicates', () => {
+    const input = [
+      'ba',
+      {
+        suggestion: [
+          { freq: 1, word: 'bar' },
+          { freq: 1, word: 'banana' },
+        ],
+      },
+      'ap',
+      {
+        suggestion: [
+          { freq: 1, word: 'api' },
+          { freq: 1, word: 'apple' },
+          { freq: 1, word: 'bar' },
+          { freq: 1, word: 'api' },
+        ],
+      },
+    ];
+    expect(getSuggestions(input)).toEqual(['api', 'apple', 'banana', 'bar']);
+  });
+
+  it('empty', () => {
+    const input = [
+      'ba',
+      {
+        suggestion: [
+          { freq: 1, word: 'bar' },
+          { freq: 1, word: 'banana' },
+        ],
+      },
+      'ap',
+      { suggestion: [] },
+    ];
+    expect(getSuggestions(input)).toEqual(['banana', 'bar']);
+  });
+});

--- a/packages/volto-solr/src/components/theme/SolrSearch/resultItems/DefaultResultItem.jsx
+++ b/packages/volto-solr/src/components/theme/SolrSearch/resultItems/DefaultResultItem.jsx
@@ -26,12 +26,12 @@ const DefaultResultItem = ({ item }) => (
         {item.title}
       </Link>
     </h2>
-    {item?.highlighting && item.highlighting.length > 0 ? (
+    {item?.extras?.highlighting && item.extras.highlighting.length > 0 ? (
       <div className="tileBody">
         <span
           className="description"
           dangerouslySetInnerHTML={{
-            __html: item.highlighting,
+            __html: item.extras.highlighting,
           }}
         />
         {' ...'}

--- a/packages/volto-solr/src/components/theme/SolrSearch/resultItems/EventResultItem.jsx
+++ b/packages/volto-solr/src/components/theme/SolrSearch/resultItems/EventResultItem.jsx
@@ -18,12 +18,12 @@ const EventResultItem = ({ item }) => (
         {item.title}
       </Link>
     </h2>
-    {item?.highlighting && item.highlighting.length > 0 ? (
+    {item?.extras?.highlighting && item.extras.highlighting.length > 0 ? (
       <div className="tileBody">
         <span
           className="description"
           dangerouslySetInnerHTML={{
-            __html: item.highlighting,
+            __html: item.extras.highlighting,
           }}
         />
         {' ...'}

--- a/packages/volto-solr/src/components/theme/SolrSearch/resultItems/ImageResultItem.jsx
+++ b/packages/volto-solr/src/components/theme/SolrSearch/resultItems/ImageResultItem.jsx
@@ -18,12 +18,12 @@ const ImageResultItem = ({ item }) => (
         {item.title}
       </Link>
     </h2>
-    {item?.highlighting && item.highlighting.length > 0 ? (
+    {item?.extras?.highlighting && item.extras.highlighting.length > 0 ? (
       <div className="tileBody">
         <span
           className="description"
           dangerouslySetInnerHTML={{
-            __html: item.highlighting,
+            __html: item.extras.highlighting,
           }}
         />
         {' ...'}

--- a/packages/volto-solr/src/components/theme/SolrSearch/resultItems/NewsItemResultItem.jsx
+++ b/packages/volto-solr/src/components/theme/SolrSearch/resultItems/NewsItemResultItem.jsx
@@ -18,12 +18,12 @@ const NewsItemResultItem = ({ item }) => (
         {item.title}
       </Link>
     </h2>
-    {item?.highlighting && item.highlighting.length > 0 ? (
+    {item?.extras?.highlighting && item.extras.highlighting.length > 0 ? (
       <div className="tileBody">
         <span
           className="description"
           dangerouslySetInnerHTML={{
-            __html: item.highlighting,
+            __html: item.extras.highlighting,
           }}
         />
         {' ...'}

--- a/packages/volto-solr/src/components/theme/SolrSearch/resultItems/PersonResultItem.jsx
+++ b/packages/volto-solr/src/components/theme/SolrSearch/resultItems/PersonResultItem.jsx
@@ -36,12 +36,12 @@ const PersonResultItem = ({ item }) => (
             {item.title}
           </Link>
         </h2>
-        {item?.highlighting && item.highlighting.length > 0 ? (
+        {item?.extras?.highlighting && item.extras.highlighting.length > 0 ? (
           <div className="tileBody">
             <span
               className="description"
               dangerouslySetInnerHTML={{
-                __html: item.highlighting,
+                __html: item.extras.highlighting,
               }}
             />
             {' ...'}

--- a/packages/volto-solr/src/components/theme/SolrSearchWidget/SolrSearchWidget.jsx
+++ b/packages/volto-solr/src/components/theme/SolrSearchWidget/SolrSearchWidget.jsx
@@ -53,11 +53,14 @@ const ID_ALL = '@ALL';
 // always be fetched currently.
 const NR_ITEMS = 8;
 
+const emptyArray = [];
+
 const SolrSearchAutosuggestRaw = (props) => {
   const originalText = props.value;
   const dispatch = useDispatch();
-  let suggestions = useSelector((state) =>
-    state.solrSearchSuggestions.items.slice(0, NR_ITEMS),
+  let suggestions = useSelector(
+    (state) =>
+      state.solrSearchSuggestions?.items?.slice(0, NR_ITEMS) || emptyArray,
   ).concat({
     '@type': 'ShowAll',
     '@id': ID_ALL,

--- a/packages/volto-solr/src/reducers/index.js
+++ b/packages/volto-solr/src/reducers/index.js
@@ -1,5 +1,5 @@
 import solrsearch from './solrsearch/solrsearch';
-import solrSearchSuggestions from './solrsearch/solrSearchSuggestions';
+import solrsearchsuggestions from './solrsearch/solrSearchSuggestions';
 import { defineMessages } from 'react-intl';
 
 // needed to add as overrides are not parsed by i18n
@@ -35,7 +35,7 @@ defineMessages({
 
 const reducers = {
   solrsearch,
-  solrSearchSuggestions,
+  solrsearchsuggestions,
 };
 
 export default reducers;

--- a/packages/volto-solr/src/reducers/solrsearch/solrSearchSuggestions.js
+++ b/packages/volto-solr/src/reducers/solrsearch/solrSearchSuggestions.js
@@ -7,7 +7,10 @@ const initialState = {
   loading: false,
 };
 
-export default function searchSuggestions(state = initialState, action = {}) {
+export default function solrSearchSuggestions(
+  state = initialState,
+  action = {},
+) {
   switch (action.type) {
     case `${GET_SOLR_SEARCH_SUGGESTIONS}_PENDING`:
       return {

--- a/packages/volto-solr/src/reducers/solrsearch/solrsearch.js
+++ b/packages/volto-solr/src/reducers/solrsearch/solrsearch.js
@@ -15,8 +15,10 @@ const initialState = {
   items: [],
   facetGroups: [],
   facetFields: [],
+  spellcheck: [],
   layouts: [],
   total: 0,
+  collationMisspellings: undefined,
   loaded: false,
   loading: false,
   batching: {},
@@ -33,10 +35,7 @@ const solrPathToPortalPath = (portal_path, path) => {
   return path;
 };
 
-const getHighlighting = (highlighting, UID) =>
-  [].concat(...(Object.values(highlighting[UID]) || {}));
-
-const mapSolrItem = (portal_path, highlighting, item) => {
+const mapSolrItem = (portal_path, item) => {
   const {
     path_string,
     Type,
@@ -59,7 +58,6 @@ const mapSolrItem = (portal_path, highlighting, item) => {
     UID, // unused
     image_field, // missing
     review_state, // missing
-    highlighting: getHighlighting(highlighting, UID),
     extras,
   };
 };
@@ -104,8 +102,10 @@ export default function search(state = initialState, action = {}) {
                 ...(state.subrequests[action.subrequest] || {
                   items: [],
                   total: 0,
+                  collationMisspellings: undefined,
                   facetGroups: [],
                   facetFields: [],
+                  spellcheck: [],
                   layouts: [],
                   batching: {},
                 }),
@@ -126,15 +126,13 @@ export default function search(state = initialState, action = {}) {
         error: null,
         items: map(
           action.result.response.docs,
-          mapSolrItem.bind(
-            null,
-            action.result.portal_path,
-            action.result.highlighting,
-          ),
+          mapSolrItem.bind(null, action.result.portal_path),
         ),
         total: action.result.response.numFound,
+        collationMisspellings: action.result.collation_misspellings,
         facetGroups: action.result.facet_groups || [],
         facetFields: action.result.facet_fields || [],
+        spellcheck: action.result.spellcheck || [],
         layouts: action.result.layouts || [],
         loaded: true,
         loading: false,
@@ -157,8 +155,10 @@ export default function search(state = initialState, action = {}) {
         error: action.error,
         items: [],
         total: 0,
+        collationMisspellings: undefined,
         facetGroups: [],
         facetFields: [],
+        spellcheck: [],
         layouts: [],
         loading: false,
         loaded: false,
@@ -187,8 +187,10 @@ export default function search(state = initialState, action = {}) {
             error: null,
             items: [],
             total: 0,
+            collationMisspellings: undefined,
             facetGroups: [],
             facetFields: [],
+            spellcheck: [],
             layouts: [],
             loading: false,
             loaded: false,

--- a/packages/volto-solr/src/reducers/solrsearch/solrsearch.test.js
+++ b/packages/volto-solr/src/reducers/solrsearch/solrsearch.test.js
@@ -10,6 +10,7 @@ describe('SOLR search reducer', () => {
     expect(search()).toEqual({
       error: null,
       items: [],
+      spellcheck: [],
       facetGroups: [],
       facetFields: [],
       layouts: [],
@@ -29,6 +30,7 @@ describe('SOLR search reducer', () => {
     ).toEqual({
       error: null,
       items: [],
+      spellcheck: [],
       facetGroups: [],
       facetFields: [],
       layouts: [],
@@ -55,7 +57,6 @@ describe('SOLR search reducer', () => {
             ],
             numFound: 1,
           },
-          highlighting: { UID1: ['<em>Blah</em>'] },
           portal_path: '/Plone',
         },
       }),
@@ -71,11 +72,11 @@ describe('SOLR search reducer', () => {
           description: undefined,
           effective: undefined,
           extras: {},
-          highlighting: ['<em>Blah</em>'],
           image_field: undefined,
           review_state: undefined,
         },
       ],
+      spellcheck: [],
       facetGroups: [],
       facetFields: [],
       layouts: [],
@@ -96,6 +97,7 @@ describe('SOLR search reducer', () => {
     ).toEqual({
       error: 'failed',
       items: [],
+      spellcheck: [],
       facetGroups: [],
       facetFields: [],
       layouts: [],
@@ -115,6 +117,7 @@ describe('SOLR search reducer', () => {
     ).toEqual({
       error: null,
       items: [],
+      spellcheck: [],
       facetGroups: [],
       facetFields: [],
       layouts: [],
@@ -135,6 +138,7 @@ describe('SOLR search reducer', () => {
     ).toEqual({
       error: null,
       items: [],
+      spellcheck: [],
       facetGroups: [],
       facetFields: [],
       layouts: [],
@@ -146,6 +150,7 @@ describe('SOLR search reducer', () => {
         'my-subrequest': {
           error: null,
           items: [],
+          spellcheck: [],
           facetGroups: [],
           facetFields: [],
           layouts: [],
@@ -166,6 +171,7 @@ describe('SOLR search reducer', () => {
             'my-subrequest': {
               error: null,
               items: [],
+              spellcheck: [],
               facetGroups: [],
               facetFields: [],
               layouts: [],
@@ -190,7 +196,6 @@ describe('SOLR search reducer', () => {
               ],
               numFound: 1,
             },
-            highlighting: { UID1: ['<em>Blah</em>'] },
             portal_path: '/Plone',
             facet_groups: [
               ['One', 1],
@@ -234,11 +239,11 @@ describe('SOLR search reducer', () => {
               description: undefined,
               effective: undefined,
               extras: {},
-              highlighting: ['<em>Blah</em>'],
               image_field: undefined,
               review_state: undefined,
             },
           ],
+          spellcheck: [],
           facetGroups: [
             ['One', 1],
             ['Two', 2],
@@ -281,6 +286,7 @@ describe('SOLR search reducer', () => {
             'my-subrequest': {
               error: null,
               items: [],
+              spellcheck: [],
               facetGroups: [],
               facetFields: [],
               layouts: [],
@@ -302,6 +308,7 @@ describe('SOLR search reducer', () => {
         'my-subrequest': {
           error: 'failed',
           items: [],
+          spellcheck: [],
           facetGroups: [],
           facetFields: [],
           layouts: [],
@@ -322,6 +329,7 @@ describe('SOLR search reducer', () => {
             'my-subrequest': {
               error: null,
               items: ['random'],
+              spellcheck: [],
               facetGroups: [],
               facetFields: [],
               layouts: [],
@@ -366,6 +374,7 @@ describe('SOLR search reducer', () => {
         ).toEqual({
           error: null,
           items: [],
+          spellcheck: [],
           facetGroups: [],
           facetFields: [],
           layouts: [],
@@ -409,6 +418,7 @@ describe('SOLR search reducer', () => {
         ).toEqual({
           error: null,
           items: [],
+          spellcheck: [],
           facetGroups: [],
           facetFields: [],
           layouts: [],
@@ -440,6 +450,7 @@ describe('SOLR search reducer', () => {
             {
               error: null,
               items: [],
+              spellcheck: [],
               facetGroups: [],
               facetFields: [],
               layouts: [],
@@ -465,6 +476,7 @@ describe('SOLR search reducer', () => {
         ).toEqual({
           error: null,
           items: [],
+          spellcheck: [],
           facetGroups: [],
           facetFields: [],
           layouts: [],
@@ -491,6 +503,7 @@ describe('SOLR search reducer', () => {
             {
               error: null,
               items: [],
+              spellcheck: [],
               facetGroups: [],
               facetFields: [],
               layouts: [],
@@ -521,6 +534,7 @@ describe('SOLR search reducer', () => {
         ).toEqual({
           error: null,
           items: [],
+          spellcheck: [],
           facetGroups: [],
           facetFields: [],
           layouts: [],


### PR DESCRIPTION
- suggestions
  - add getSuggestions helper
  - support "did you mean" results
  - fix tests
  - update xmlconfig
- update highlighting after kitconcept.solr change
  - remove old highlighting support, as now done on the backend
  - use highlighting from extras
- update i18n
- fix corepack installation in CI workflows
- update docker comfiguration
  - docker fixes
  - add ipv4 fix to dockerfile
- set volto version to 18.9.1
- make solrsearchwidget more resilient for missing redux data